### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 :spring_boot_version: 2.1.3.RELEASE
-:SpringApplication: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
-:runner: http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-command-line-runner
+:SpringApplication: https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
+:runner: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-command-line-runner
 :toc:
 :icons: font
 :source-highlighter: prettify
@@ -9,7 +9,7 @@ This guide walks you through the process of wrapping database operations with no
 
 == What you'll build
 
-You'll build a simple JDBC application wherein you make database operations transactional without having to write http://docs.oracle.com/javase/tutorial/jdbc/basics/transactions.html#commit_transactions[specialized JDBC code].
+You'll build a simple JDBC application wherein you make database operations transactional without having to write https://docs.oracle.com/javase/tutorial/jdbc/basics/transactions.html#commit_transactions[specialized JDBC code].
 
 
 == What you'll need
@@ -56,7 +56,7 @@ include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/
 
 Your application has actually zero configuration. Spring Boot will detect `spring-jdbc` on the classpath and `h2` and will create a `DataSource` and a `JdbcTemplate` for you automatically. Because such infrastructure is now available and you have no dedicated configuration, a `DataSourceTransactionManager` will also be created for you: this is the component that intercepts the `@Transactional` annotated method (e.g. the `book` on `BookingService`). The `BookingService` is detected via classpath scanning.
 
-Another Spring Boot feature demonstrated in this guide is http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-initialize-a-database-using-spring-jdbc[the ability to initialize the schema on startup]:
+Another Spring Boot feature demonstrated in this guide is https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-initialize-a-database-using-spring-jdbc[the ability to initialize the schema on startup]:
 
 `src/main/resources/schema.sql`
 [source,sql]


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.oracle.com/javase/tutorial/jdbc/basics/transactions.html with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/tutorial/jdbc/basics/transactions.html ([https](https://docs.oracle.com/javase/tutorial/jdbc/basics/transactions.html) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/ ([https](https://docs.spring.io/spring-boot/docs/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/) result 200).